### PR TITLE
fix(runtime): make Engine.World awake errors escalate the stack as expected

### DIFF
--- a/.changeset/thin-actors-fold.md
+++ b/.changeset/thin-actors-fold.md
@@ -1,0 +1,5 @@
+---
+"@jolly-pixel/runtime": patch
+---
+
+Fix loadRuntime so error throw in world.connect() can escalate the stack

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -95,14 +95,14 @@ export async function loadRuntime(
       await loadingCompletePromise;
     }
 
-    await loadingComponent.complete(() => {
-      runtime.canvas.style.opacity = "1";
-      runtime.start();
-    });
+    await loadingComponent.complete();
   }
   catch (error: any) {
     loadingComponent.error(error);
   }
+
+  runtime.canvas.style.opacity = "1";
+  runtime.start();
 }
 
 export { Runtime, type RuntimeOptions };


### PR DESCRIPTION
close #128 