### PR TITLE
fix(pixel-draw-renderer): Implemented Shift+right-click line drawing with the secondary brush color.

### DIFF
--- a/.changeset/upset-dogs-roll.md
+++ b/.changeset/upset-dogs-roll.md
@@ -1,0 +1,5 @@
+---
+"@jolly-pixel/pixel-draw.renderer": patch
+---
+
+Implemented Shift+right-click line drawing with the secondary brush color.

--- a/packages/pixel-draw-renderer/docs/PixelArtCanvas.md
+++ b/packages/pixel-draw-renderer/docs/PixelArtCanvas.md
@@ -149,7 +149,7 @@ set mode(mode: Mode)
 
 | Mode | Left-click | Right-click |
 |---|---|---|
-| `"paint"` | Stroke with `brush.primary`. Hold `Shift` for straight-line. | Stroke with `brush.secondary`. |
+| `"paint"` | Stroke with `brush.primary`. Hold `Shift` for straight-line. | Stroke with `brush.secondary`. Hold `Shift` for straight-line. |
 | `"move"` | Pan camera. | — |
 | `"fill"` | Flood-fill with `brush.primary`. | Same with `brush.secondary`. |
 | `"select"` | Drag to select/move rectangle. `Ctrl+C/V` copy/paste, `Delete` erase, `R` rotate 90°, `H`/`V` flip. | — |

--- a/packages/pixel-draw-renderer/src/input/modes/PaintMode.ts
+++ b/packages/pixel-draw-renderer/src/input/modes/PaintMode.ts
@@ -66,7 +66,7 @@ export class PaintMode extends InteractionMode {
       this.#line.isArmed &&
       this.#line.commitTrigger === "mousedown"
     ) {
-      this.#line.commit();
+      this.#line.commit("primary");
 
       return false;
     }
@@ -96,6 +96,15 @@ export class PaintMode extends InteractionMode {
   ): boolean | void {
     if (ctrlKey) {
       this.#brush.pick(pos.x, pos.y);
+
+      return false;
+    }
+
+    if (
+      this.#line.isArmed &&
+      this.#line.commitTrigger === "mousedown"
+    ) {
+      this.#line.commit("secondary");
 
       return false;
     }

--- a/packages/pixel-draw-renderer/src/tools/LineController.ts
+++ b/packages/pixel-draw-renderer/src/tools/LineController.ts
@@ -3,7 +3,10 @@ import {
   Line,
   type LineCommitTrigger
 } from "./Line.ts";
-import type { Brush } from "./Brush.ts";
+import type {
+  Brush,
+  BrushColorSlot
+} from "./Brush.ts";
 import type { EditPipeline } from "../sync/EditPipeline.ts";
 import type { LinePreviewOverlay } from "../rendering/overlays/LinePreviewOverlay.ts";
 import type { Vec2 } from "../types.ts";
@@ -25,6 +28,7 @@ export class LineController {
 
   #lastCursorPos: Vec2 | null = null;
   #isShiftHeld = false;
+  #colorSlot: BrushColorSlot = "primary";
 
   constructor(
     options: LineControllerOptions
@@ -62,7 +66,8 @@ export class LineController {
   }
 
   arm(
-    commitTrigger: LineCommitTrigger
+    commitTrigger: LineCommitTrigger,
+    colorSlot: BrushColorSlot = "primary"
   ): void {
     if (!this.#lastCursorPos) {
       return;
@@ -72,13 +77,16 @@ export class LineController {
       this.#lastCursorPos,
       commitTrigger
     );
+    this.#colorSlot = colorSlot;
     this.refreshPreview();
   }
 
   /**
     * Commits the armed line segment.
    */
-  commit(): void {
+  commit(
+    colorSlot: BrushColorSlot = this.#colorSlot
+  ): void {
     const points = this.#line.commit();
     this.#linePreview.clear();
     if (!points) {
@@ -86,7 +94,8 @@ export class LineController {
     }
 
     this.#pipeline.commitPixels(
-      this.#stampLinePixels(points)
+      this.#stampLinePixels(points),
+      colorSlot
     );
 
     if (this.#isShiftHeld) {
@@ -94,6 +103,7 @@ export class LineController {
         points.at(-1) ?? points[0],
         "mousedown"
       );
+      this.#colorSlot = colorSlot;
       this.refreshPreview();
     }
   }

--- a/packages/pixel-draw-renderer/test/PixelArtCanvas.line.spec.ts
+++ b/packages/pixel-draw-renderer/test/PixelArtCanvas.line.spec.ts
@@ -66,6 +66,37 @@ describe("PixelArtCanvas — line tool (Shift)", () => {
     manager.destroy();
   });
 
+  test("Shift-arm-then-right-click commits a line with the secondary color", () => {
+    const events: PixelBufferHookEvent[] = [];
+    const manager = createPixelArtCanvas({
+      texture: { size: { x: 16, y: 16 } },
+      zoom: { default: 4 },
+      brush: {
+        size: 1,
+        maxSize: 1,
+        color: "#FF0000",
+        secondaryColor: "#00FF00"
+      },
+      onBufferUpdated: (event) => events.push(event)
+    }).manager;
+    const canvas = manager.canvas();
+
+    moveTo(canvas, 100, 100);
+    window.dispatchEvent(shiftKeyDown());
+    moveTo(canvas, 128, 100);
+
+    canvas.dispatchEvent(new MouseEvent("mousedown", {
+      button: 2, buttons: 2, clientX: 128, clientY: 100, bubbles: true
+    }));
+
+    assert.strictEqual(events.length, 1);
+    const event = events[0];
+    assert.strictEqual(event.action, "stroke");
+    assert.deepStrictEqual(event.metadata.color, { r: 0, g: 255, b: 0, a: 255 });
+    assert.strictEqual(event.metadata.positions.length, 8);
+    manager.destroy();
+  });
+
   test("committing via mousedown does not chain into a freehand stroke while still held", () => {
     const events: PixelBufferHookEvent[] = [];
     const manager = makeManager((event) => events.push(event));


### PR DESCRIPTION
close #427 