### PR TITLE
fix(engine): ignore key events from editable targets, free Tab and Escape

### DIFF
--- a/.changeset/engine-keyboard-editable-guard.md
+++ b/.changeset/engine-keyboard-editable-guard.md
@@ -1,0 +1,26 @@
+---
+"@jolly-pixel/engine": minor
+---
+
+`Keyboard` no longer competes with focused UI for the keyboard.
+
+Two changes, both fixing cases where the engine consumed keystrokes meant for a control:
+
+- `keydown` and `keypress` are ignored when the event originates inside an editable element
+  (`input`, `textarea`, `contenteditable`). Previously the listener attached to `document` and
+  inspected no target, so typing in a text field also drove the camera, and `keypress` fed the
+  typed characters into `keyboard.char`. The check is exported as `isEditableTarget(event)` and
+  resolves through `composedPath()`, so a control inside a shadow root is matched rather than the
+  custom element it was retargeted to. `keyup` is deliberately not filtered: dropping a release
+  would leave a key held on the canvas stuck in `buttonsDown` after focus moved to a field.
+
+- `Tab` and `Escape` are removed from the prevented key set. Preventing `Tab` trapped focus on the
+  canvas, so a keyboard user could never reach surrounding UI, which also defeated any attempt to
+  gate input from the UI side. Preventing `Escape` suppressed the browser default action that
+  native `dialog` closes on.
+
+Both keys still emit as before, so a game that wants the old behaviour can prevent them itself:
+
+```ts
+keyboard.on("Tab", (event) => event.preventDefault());
+```

--- a/packages/engine/src/controls/devices/keyboard/Keyboard.class.ts
+++ b/packages/engine/src/controls/devices/keyboard/Keyboard.class.ts
@@ -22,8 +22,6 @@ const kControlKeys = new Set([
   "End",
   "Insert",
   "Delete",
-  "Tab",
-  "Escape",
   "F1",
   "F2",
   "F3",
@@ -49,6 +47,57 @@ const kControlKeys = new Set([
   "F23",
   "F24"
 ]);
+
+/**
+ * `Tab` and `Escape` are deliberately absent. Preventing `Tab` traps focus on the canvas, so a
+ * keyboard user can never reach surrounding UI, and preventing `Escape` suppresses the browser
+ * default action native `dialog` closes on. Both still emit, so a consumer wanting the old
+ * behaviour can call `keyboard.on("Tab", (event) => event.preventDefault())`.
+ */
+
+const kEditableTagNames = new Set([
+  "INPUT",
+  "TEXTAREA"
+]);
+
+function isEditableElement(
+  target: unknown
+): boolean {
+  if (target === null || typeof target !== "object") {
+    return false;
+  }
+
+  if ("isContentEditable" in target && target.isContentEditable === true) {
+    return true;
+  }
+
+  return "tagName" in target &&
+    typeof target.tagName === "string" &&
+    kEditableTagNames.has(target.tagName);
+}
+
+/**
+ * Whether a key event originated inside an editable control, in which case the engine must ignore
+ * it so typing does not also drive the game.
+ *
+ * Resolved through `composedPath()`: shadow DOM retargets `event.target` to the host, so a control
+ * inside a shadow root would otherwise report as its custom element. The whole path is scanned so
+ * a text node inside a `contenteditable` ancestor still matches.
+ */
+export interface KeyEventTargetLike {
+  target?: unknown;
+  composedPath?: () => readonly unknown[];
+}
+
+export function isEditableTarget(
+  event: KeyEventTargetLike
+): boolean {
+  if (typeof event.composedPath === "function") {
+    return event.composedPath().some(isEditableElement);
+  }
+
+  return isEditableElement(event.target);
+}
 
 export type KeyboardEvents = {
   down: [event: KeyboardEvent];
@@ -136,7 +185,7 @@ export class Keyboard extends EventEmitter<
   }
 
   #onKeyDown = (event: KeyboardEvent) => {
-    if (!this.#enabled) {
+    if (!this.#enabled || isEditableTarget(event)) {
       return;
     }
 
@@ -165,7 +214,7 @@ export class Keyboard extends EventEmitter<
   };
 
   #onKeyPress = (event: KeyboardEvent) => {
-    if (!this.#enabled) {
+    if (!this.#enabled || isEditableTarget(event)) {
       return;
     }
 
@@ -175,6 +224,11 @@ export class Keyboard extends EventEmitter<
     }
   };
 
+  /**
+   * Not guarded by `isEditableTarget`, unlike keydown and keypress. Holding a key on the canvas
+   * then focusing a field before releasing would otherwise leave it in `buttonsDown` forever.
+   * Deleting a key that was never added is a no-op, so releases are always safe to process.
+   */
   #onKeyUp = (event: KeyboardEvent) => {
     if (!this.#enabled) {
       return;

--- a/packages/engine/test/controls/Keyboard.spec.ts
+++ b/packages/engine/test/controls/Keyboard.spec.ts
@@ -6,7 +6,7 @@ import assert from "node:assert/strict";
 import { Window } from "happy-dom";
 
 // Import Internal Dependencies
-import { Keyboard, type KeyCode } from "../../src/controls/devices/index.ts";
+import { Keyboard, isEditableTarget, type KeyCode } from "../../src/controls/devices/index.ts";
 import * as mocks from "./mocks/index.ts";
 
 // CONSTANTS
@@ -221,11 +221,128 @@ describe("Controls.Keyboard", () => {
       assert.equal(keyboard.buttonsDown.has("KeyA"), true);
     });
   });
+
+  describe("editable targets", () => {
+    test("keydown inside an editable control is ignored", () => {
+      documentAdapter.dispatchEvent("keydown", {
+        code: "KeyW",
+        target: createElement("input")
+      });
+      keyboard.update();
+
+      assert.equal(keyboard.buttonsDown.has("KeyW"), false);
+      assert.equal(keyboard.buttons.size, 0);
+    });
+
+    test("keypress inside an editable control does not accumulate char", () => {
+      documentAdapter.dispatchEvent("keypress", {
+        key: "a",
+        target: createElement("textarea")
+      });
+      keyboard.update();
+
+      assert.equal(keyboard.char, "");
+    });
+
+    test("keyup is never ignored, so a key held on the canvas releases inside a field", () => {
+      documentAdapter.dispatchEvent("keydown", { code: "KeyW" });
+      keyboard.update();
+      assert.equal(keyboard.buttonsDown.has("KeyW"), true);
+
+      documentAdapter.dispatchEvent("keyup", {
+        code: "KeyW",
+        target: createElement("input")
+      });
+      keyboard.update();
+
+      assert.equal(keyboard.buttonsDown.has("KeyW"), false);
+    });
+
+    test("keydown on a non editable target is still tracked", () => {
+      documentAdapter.dispatchEvent("keydown", {
+        code: "KeyW",
+        target: createElement("div")
+      });
+      keyboard.update();
+
+      assert.equal(keyboard.buttonsDown.has("KeyW"), true);
+    });
+  });
+
+  describe("control keys", () => {
+    test("Tab is not prevented, so focus can leave the canvas", () => {
+      const event = documentAdapter.dispatchEvent("keydown", { code: "Tab" });
+
+      assert.equal(event.defaultPrevented, false);
+      assert.equal(keyboard.buttonsDown.has("Tab"), true);
+    });
+
+    test("Escape is not prevented, so native dialog can close on it", () => {
+      const event = documentAdapter.dispatchEvent("keydown", { code: "Escape" });
+
+      assert.equal(event.defaultPrevented, false);
+      assert.equal(keyboard.buttonsDown.has("Escape"), true);
+    });
+
+    test("other control keys are still prevented", () => {
+      const event = documentAdapter.dispatchEvent("keydown", { code: "ArrowUp" });
+
+      assert.equal(event.defaultPrevented, true);
+    });
+  });
 });
+
+describe("Controls.isEditableTarget", () => {
+  test("matches an input anywhere in the composed path", () => {
+    assert.equal(
+      isEditableTarget({
+        target: createElement("jolly-pane"),
+        composedPath: () => [createElement("span"), createElement("input")]
+      }),
+      true
+    );
+  });
+
+  test("prefers the composed path over target, which shadow DOM retargets to the host", () => {
+    assert.equal(
+      isEditableTarget({
+        target: createElement("input"),
+        composedPath: () => [createElement("div")]
+      }),
+      false
+    );
+  });
+
+  test("matches a contenteditable element", () => {
+    assert.equal(
+      isEditableTarget({ composedPath: () => [{ isContentEditable: true }] }),
+      true
+    );
+  });
+
+  test("falls back to target when composedPath is absent, as on synthetic events", () => {
+    assert.equal(isEditableTarget({ target: createElement("textarea") }), true);
+    assert.equal(isEditableTarget({ target: createElement("div") }), false);
+  });
+
+  test("tolerates a missing or non object target", () => {
+    assert.equal(isEditableTarget({}), false);
+    assert.equal(isEditableTarget({ target: null }), false);
+    assert.equal(isEditableTarget({ target: "input" }), false);
+  });
+});
+
+function createElement(
+  tagName: string
+) {
+  return kEmulatedBrowserWindow.document.createElement(tagName);
+}
 
 interface EventData {
   code?: KeyCode;
   key?: string;
+  /** Stands in for the composed path, which an undispatched event cannot supply. */
+  target?: unknown;
 }
 
 class KeyboardDocumentAdapter extends mocks.DocumentAdapter {
@@ -240,7 +357,15 @@ class KeyboardDocumentAdapter extends mocks.DocumentAdapter {
       cancelable: true
     });
 
+    if ("target" in eventData) {
+      Object.defineProperty(event, "composedPath", {
+        value: () => [eventData.target]
+      });
+    }
+
     const listeners = this.listeners.get(type) ?? [];
     listeners.forEach((listener) => listener(event));
+
+    return event;
   }
 }


### PR DESCRIPTION
Keyboard attached to document and inspected no target, so every keystroke reached the engine regardless of focus: typing in a text field drove the camera, and keypress fed the typed characters into keyboard.char.

Guard keydown and keypress with an exported isEditableTarget(), resolved through composedPath() so a control inside a shadow root is matched rather than the host it was retargeted to. keyup stays unguarded: dropping a release would leave a key held on the canvas stuck in buttonsDown after focus moved to a field, and deleting a key that was never added is a no-op.

Remove Tab and Escape from kControlKeys. Preventing Tab trapped focus on the canvas, so the keyboard could never reach surrounding UI, which also defeats gating input from the UI side. Preventing Escape suppressed the browser default action native dialog closes on. Both still emit, so a consumer can restore the old behaviour with a listener.