### PR TITLE
feat(pixel-draw-renderer): Selection overlay shows its size (16×16) next to the outline

### DIFF
--- a/.changeset/olive-poems-smile.md
+++ b/.changeset/olive-poems-smile.md
@@ -1,0 +1,7 @@
+---
+"@jolly-pixel/pixel-draw.renderer": minor
+---
+
+Selection overlay shows its size ("16×16") next to the outline, anchored
+below the bottom-right corner. Opt out with `select.sizeLabel: false`.
+`DefaultViewport` gains `canvasWidth` / `canvasHeight`.

--- a/packages/pixel-draw-renderer/docs/PixelArtCanvas.md
+++ b/packages/pixel-draw-renderer/docs/PixelArtCanvas.md
@@ -70,14 +70,18 @@ Creates, moves and selects texture regions. See [`UVMap`](./uv/UVMap.md).
 
 ### `viewport`
 
-Read-only camera and zoom state:
+Read-only camera and zoom state, plus the canvas element size in screen pixels:
 
 ```ts
 interface DefaultViewport {
   readonly camera: Readonly<Vec2>;
   readonly zoom: Zoom;
+  readonly canvasWidth: number;
+  readonly canvasHeight: number;
 }
 ```
+
+`canvasWidth` and `canvasHeight` are `0` until the canvas is first sized, and follow every resize.
 
 ## Interaction
 

--- a/packages/pixel-draw-renderer/docs/PixelArtCanvasOptions.md
+++ b/packages/pixel-draw-renderer/docs/PixelArtCanvasOptions.md
@@ -55,6 +55,7 @@ interface BackgroundTransparencyOptions {
 
 interface SelectOptions {
   eraseColor?: ColorInput;
+  sizeLabel?: boolean;
 }
 
 interface HistoryOptions {
@@ -150,6 +151,12 @@ Initial brush colors, size and highlight colors. See [`BrushOptions`](./tools/Br
 ### `select.eraseColor`
 
 Color used for pixels vacated by selection deletion, movement or transforms. When omitted, the canvas uses the dominant neighboring color and falls back to transparency when no in-bounds neighbor exists.
+
+### `select.sizeLabel`
+
+Whether the selection shows its size as `16×16` next to the outline. It defaults to `true`.
+
+The label reports the bounding box in texture pixels, including for shape selections, and follows the selection while it is created, moved and transformed. It is anchored below the bottom-right corner, flips above the selection near the bottom of the viewport, and hides when the selection scrolls out of view or measures less than 2 pixels on either axis. It is local only: peer selections never show one.
 
 ## History
 

--- a/packages/pixel-draw-renderer/src/CanvasView.ts
+++ b/packages/pixel-draw-renderer/src/CanvasView.ts
@@ -42,6 +42,11 @@ export interface CanvasViewOptions {
    * @default null (dominant neighbor color)
    */
   eraseColor?: RGBA8 | null;
+  /**
+   * Whether the selection outline shows its size.
+   * @default true
+   */
+  selectionSizeLabel?: boolean;
 }
 
 /**
@@ -105,7 +110,8 @@ export class CanvasView {
       parent,
       viewport: this.viewport,
       brush: options.brushHighlight,
-      uvMap: doc.uv
+      uvMap: doc.uv,
+      selectionSizeLabel: options.selectionSizeLabel
     });
 
     this.peerPresence = new PeerPresence({

--- a/packages/pixel-draw-renderer/src/PixelArtCanvas.ts
+++ b/packages/pixel-draw-renderer/src/PixelArtCanvas.ts
@@ -113,6 +113,11 @@ export interface PixelArtCanvasOptions {
      * @default dominant neighbor color, then transparent
      */
     eraseColor?: ByteColorInput;
+    /**
+     * Whether the selection shows its size next to the outline.
+     * @default true
+     */
+    sizeLabel?: boolean;
   };
   /**
    * Called after a local edit commits to the master buffer.
@@ -224,7 +229,8 @@ export class PixelArtCanvas {
       background: options.backgroundColor,
       backgroundTransparency: options.backgroundTransparency,
       brushHighlight: brushAdapter,
-      eraseColor
+      eraseColor,
+      selectionSizeLabel: options.select?.sizeLabel
     });
     this.viewport = this.#view.viewport;
     this.peerPresence = this.#view.peerPresence;

--- a/packages/pixel-draw-renderer/src/rendering/Viewport.ts
+++ b/packages/pixel-draw-renderer/src/rendering/Viewport.ts
@@ -12,6 +12,8 @@ import type {
 export interface DefaultViewport {
   readonly zoom: Zoom;
   readonly camera: Readonly<Vec2>;
+  readonly canvasWidth: number;
+  readonly canvasHeight: number;
 }
 
 /**
@@ -106,6 +108,14 @@ export class Viewport extends Emitter<
 
   get texture(): ViewportTexture {
     return this.#texture;
+  }
+
+  get canvasWidth(): number {
+    return this.#canvasWidth;
+  }
+
+  get canvasHeight(): number {
+    return this.#canvasHeight;
   }
 
   updateCanvasSize(

--- a/packages/pixel-draw-renderer/src/rendering/overlays/OverlayLayer.ts
+++ b/packages/pixel-draw-renderer/src/rendering/overlays/OverlayLayer.ts
@@ -20,6 +20,11 @@ export interface OverlayLayerOptions {
   viewport: DefaultViewport;
   brush: BrushHighlight;
   uvMap: UVMap;
+  /**
+   * Whether the selection outline shows its size.
+   * @default true
+   */
+  selectionSizeLabel?: boolean;
 }
 
 /**
@@ -66,7 +71,8 @@ export class OverlayLayer {
     this.selection = new SelectionOutline(
       this.#svg,
       options.viewport,
-      options.brush
+      options.brush,
+      { sizeLabel: options.selectionSizeLabel }
     );
     this.peerCursors = new PeerCursors(
       this.#svg,

--- a/packages/pixel-draw-renderer/src/rendering/overlays/SelectionOutline.ts
+++ b/packages/pixel-draw-renderer/src/rendering/overlays/SelectionOutline.ts
@@ -4,6 +4,7 @@ import {
   selectionContourPath,
   traceSelectionContour
 } from "./selectionContour.ts";
+import { SelectionSizeLabel } from "./SelectionSizeLabel.ts";
 import type {
   DefaultViewport
 } from "../Viewport.ts";
@@ -12,17 +13,27 @@ import type {
   SelectionRect
 } from "../../types.ts";
 
+export interface SelectionOutlineOptions {
+  /**
+   * Whether the outline shows the selection size next to it.
+   * @default true
+   */
+  sizeLabel?: boolean;
+}
+
 export class SelectionOutline {
   #viewport: DefaultViewport;
   #outline: SVGRectElement;
   #inline: SVGRectElement;
   #outlinePath: SVGPathElement;
   #inlinePath: SVGPathElement;
+  #sizeLabel: SelectionSizeLabel | null;
 
   constructor(
     svg: SVGElement,
     viewport: DefaultViewport,
-    brush: BrushHighlight
+    brush: BrushHighlight,
+    options: SelectionOutlineOptions = {}
   ) {
     this.#viewport = viewport;
 
@@ -33,6 +44,10 @@ export class SelectionOutline {
     const [outlinePath, inlinePath] = this.#initPaths(svg, brush);
     this.#outlinePath = outlinePath;
     this.#inlinePath = inlinePath;
+
+    this.#sizeLabel = options.sizeLabel === false
+      ? null
+      : new SelectionSizeLabel(svg, viewport, brush);
   }
 
   #initRects(
@@ -121,6 +136,8 @@ export class SelectionOutline {
       el.setAttribute("height", String(height));
       el.setAttribute("visibility", "visible");
     }
+
+    this.#sizeLabel?.draw(rect);
   }
 
   drawMask(
@@ -153,6 +170,8 @@ export class SelectionOutline {
       el.setAttribute("d", d);
       el.setAttribute("visibility", "visible");
     }
+
+    this.#sizeLabel?.draw(rect);
   }
 
   clear(): void {
@@ -160,5 +179,6 @@ export class SelectionOutline {
     this.#inline.setAttribute("visibility", "hidden");
     this.#outlinePath.setAttribute("visibility", "hidden");
     this.#inlinePath.setAttribute("visibility", "hidden");
+    this.#sizeLabel?.clear();
   }
 }

--- a/packages/pixel-draw-renderer/src/rendering/overlays/SelectionSizeLabel.ts
+++ b/packages/pixel-draw-renderer/src/rendering/overlays/SelectionSizeLabel.ts
@@ -1,0 +1,105 @@
+// Import Internal Dependencies
+import { clamp } from "../../utils/math.ts";
+import { SVG_NS } from "../constants.ts";
+import type {
+  DefaultViewport
+} from "../Viewport.ts";
+import type {
+  BrushHighlight,
+  SelectionRect
+} from "../../types.ts";
+
+// CONSTANTS
+const kFontSize = 10;
+const kGap = 14;
+const kMargin = 4;
+const kMinSize = 2;
+const kCharWidth = 6.2;
+
+/**
+ * Local-only "16×16" readout anchored below the bottom-right corner of the selection.
+ */
+export class SelectionSizeLabel {
+  #viewport: DefaultViewport;
+  #text: SVGTextElement;
+
+  constructor(
+    svg: SVGElement,
+    viewport: DefaultViewport,
+    brush: BrushHighlight
+  ) {
+    this.#viewport = viewport;
+    this.#text = SelectionSizeLabel.#createText(brush);
+    svg.appendChild(this.#text);
+  }
+
+  static #createText(
+    brush: BrushHighlight
+  ): SVGTextElement {
+    const text = document.createElementNS(SVG_NS, "text");
+    text.setAttribute("data-overlay", "selection-size");
+    text.setAttribute("font-size", String(kFontSize));
+    text.setAttribute("text-anchor", "end");
+    text.setAttribute("fill", brush.colorOutline);
+    text.setAttribute("paint-order", "stroke");
+    text.setAttribute("stroke", brush.colorInline);
+    text.setAttribute("stroke-width", "3");
+    text.setAttribute("stroke-linejoin", "round");
+    text.setAttribute("visibility", "hidden");
+    Object.assign(text.style, {
+      pointerEvents: "none"
+    });
+
+    return text;
+  }
+
+  draw(
+    rect: SelectionRect
+  ): void {
+    if (rect.width < kMinSize || rect.height < kMinSize) {
+      this.clear();
+
+      return;
+    }
+
+    const zoom = this.#viewport.zoom.value;
+    const camera = this.#viewport.camera;
+    const canvasWidth = this.#viewport.canvasWidth;
+    const canvasHeight = this.#viewport.canvasHeight;
+    const left = rect.x * zoom + camera.x;
+    const top = rect.y * zoom + camera.y;
+    const right = left + rect.width * zoom;
+    const bottom = top + rect.height * zoom;
+
+    const offscreen = right < 0 ||
+      bottom < 0 ||
+      left > canvasWidth ||
+      top > canvasHeight;
+    if (offscreen) {
+      this.clear();
+
+      return;
+    }
+
+    const label = `${rect.width}×${rect.height}`;
+    const width = label.length * kCharWidth;
+    const below = bottom + kGap;
+    // Flip above the box rather than let the label fall out of view.
+    const y = below > canvasHeight - kMargin ? top - kGap + kFontSize : below;
+
+    this.#text.textContent = label;
+    this.#text.setAttribute(
+      "x",
+      String(clamp(right, kMargin + width, canvasWidth - kMargin))
+    );
+    this.#text.setAttribute(
+      "y",
+      String(clamp(y, kMargin + kFontSize, canvasHeight - kMargin))
+    );
+    this.#text.setAttribute("visibility", "visible");
+  }
+
+  clear(): void {
+    this.#text.setAttribute("visibility", "hidden");
+  }
+}

--- a/packages/pixel-draw-renderer/test/PixelArtCanvas.select-size-label.spec.ts
+++ b/packages/pixel-draw-renderer/test/PixelArtCanvas.select-size-label.spec.ts
@@ -1,0 +1,91 @@
+// Import Node.js Dependencies
+import {
+  describe,
+  test,
+  beforeEach
+} from "node:test";
+import assert from "node:assert/strict";
+
+// Import Internal Dependencies
+import {
+  PixelArtCanvas,
+  type PixelArtCanvasOptions
+} from "#src/PixelArtCanvas.ts";
+import { makeContainer } from "./helpers/dom.ts";
+import { mouseEvent } from "./helpers/events.ts";
+
+describe("PixelArtCanvas — selection size label", () => {
+  let container: HTMLDivElement;
+  // Appended in order: the interactive canvas, then the SVG overlay.
+  let appended: HTMLCanvasElement[];
+
+  beforeEach(() => {
+    ({ container, children: appended } = makeContainer());
+  });
+
+  // 200x200 container, 8x8 texture, zoom 4 -> centered camera (84, 84).
+  function makeManager(
+    options: PixelArtCanvasOptions = {}
+  ): PixelArtCanvas {
+    return new PixelArtCanvas(container, {
+      texture: {
+        maxSize: 32,
+        size: { x: 8, y: 8 }
+      },
+      zoom: { default: 4 },
+      ...options
+    });
+  }
+
+  function sizeLabel(): Element | null {
+    return appended[1].querySelector(
+      "[data-overlay='selection-size']"
+    );
+  }
+
+  function dragSelection(
+    manager: PixelArtCanvas
+  ): void {
+    const canvas = manager.canvas();
+
+    manager.mode = "select";
+    // client 92..100 -> texture (2,2)..(4,4), a 3x3 selection.
+    canvas.dispatchEvent(mouseEvent("mousedown", 92, 92));
+    canvas.dispatchEvent(mouseEvent("mousemove", 100, 100));
+    canvas.dispatchEvent(
+      new MouseEvent("mouseup", { bubbles: true })
+    );
+  }
+
+  test("a dragged selection shows its size, and deselecting hides it", () => {
+    const manager = makeManager();
+
+    dragSelection(manager);
+
+    assert.strictEqual(sizeLabel()?.textContent, "3×3");
+    assert.strictEqual(
+      sizeLabel()?.getAttribute("visibility"),
+      "visible"
+    );
+
+    // Leaving select mode deselects.
+    manager.mode = "paint";
+
+    assert.strictEqual(
+      sizeLabel()?.getAttribute("visibility"),
+      "hidden"
+    );
+    manager.destroy();
+  });
+
+  test("select.sizeLabel: false renders no label", () => {
+    const manager = makeManager({
+      select: { sizeLabel: false }
+    });
+
+    dragSelection(manager);
+
+    assert.strictEqual(sizeLabel(), null);
+    manager.destroy();
+  });
+});

--- a/packages/pixel-draw-renderer/test/helpers/overlay.ts
+++ b/packages/pixel-draw-renderer/test/helpers/overlay.ts
@@ -14,20 +14,27 @@ import type {
   Vec2
 } from "#src/types.ts";
 
-type MutableViewport = DefaultViewport & { camera: Vec2; };
+type MutableViewport = DefaultViewport & {
+  camera: Vec2;
+  canvasWidth: number;
+  canvasHeight: number;
+};
 
 export function makeSvg(): SVGElement {
   return document.createElementNS(SVG_NS, "svg");
 }
 
 export function makeViewport(
-  zoom = 4
+  zoom = 4,
+  canvas: Vec2 = { x: 800, y: 600 }
 ): MutableViewport {
   return {
     zoom: new Zoom({
       default: zoom
     }),
-    camera: { x: 0, y: 0 }
+    camera: { x: 0, y: 0 },
+    canvasWidth: canvas.x,
+    canvasHeight: canvas.y
   };
 }
 

--- a/packages/pixel-draw-renderer/test/rendering/overlays/SelectionOutline.spec.ts
+++ b/packages/pixel-draw-renderer/test/rendering/overlays/SelectionOutline.spec.ts
@@ -164,6 +164,90 @@ describe("SelectionOutline", () => {
     });
   });
 
+  describe("size label", () => {
+    test("drawRect() shows the selection size", () => {
+      const svg = makeSvg();
+      const overlay = new SelectionOutline(
+        svg,
+        makeViewport(),
+        makeBrush()
+      );
+
+      overlay.drawRect({
+        x: 0,
+        y: 0,
+        width: 16,
+        height: 16
+      });
+
+      const label = svg.querySelector("[data-overlay='selection-size']")!;
+      assert.strictEqual(label.getAttribute("visibility"), "visible");
+      assert.strictEqual(label.textContent, "16×16");
+    });
+
+    test("drawMask() reports the bounding box, not the traced mask", () => {
+      const svg = makeSvg();
+      const overlay = new SelectionOutline(
+        svg,
+        makeViewport(),
+        makeBrush()
+      );
+
+      overlay.drawMask({
+        x: 0,
+        y: 0,
+        width: 2,
+        height: 2
+      }, [true, false, false, false]);
+
+      const label = svg.querySelector("[data-overlay='selection-size']")!;
+      assert.strictEqual(label.getAttribute("visibility"), "visible");
+      assert.strictEqual(label.textContent, "2×2");
+    });
+
+    test("clear() hides the size label", () => {
+      const svg = makeSvg();
+      const overlay = new SelectionOutline(
+        svg,
+        makeViewport(),
+        makeBrush()
+      );
+
+      overlay.drawRect({
+        x: 0,
+        y: 0,
+        width: 4,
+        height: 4
+      });
+      overlay.clear();
+
+      const label = svg.querySelector("[data-overlay='selection-size']")!;
+      assert.strictEqual(label.getAttribute("visibility"), "hidden");
+    });
+
+    test("sizeLabel: false creates no label at all", () => {
+      const svg = makeSvg();
+      const overlay = new SelectionOutline(
+        svg,
+        makeViewport(),
+        makeBrush(),
+        { sizeLabel: false }
+      );
+
+      overlay.drawRect({
+        x: 0,
+        y: 0,
+        width: 4,
+        height: 4
+      });
+
+      assert.strictEqual(
+        svg.querySelector("[data-overlay='selection-size']"),
+        null
+      );
+    });
+  });
+
   describe("traceSelectionContour", () => {
     test("a full rectangle mask traces its 4 corners, clockwise", () => {
       const loops = traceSelectionContour(

--- a/packages/pixel-draw-renderer/test/rendering/overlays/SelectionSizeLabel.spec.ts
+++ b/packages/pixel-draw-renderer/test/rendering/overlays/SelectionSizeLabel.spec.ts
@@ -1,0 +1,214 @@
+// Import Node.js Dependencies
+import {
+  describe,
+  test
+} from "node:test";
+import assert from "node:assert/strict";
+
+// Import Internal Dependencies
+import {
+  SelectionSizeLabel
+} from "#src/rendering/overlays/SelectionSizeLabel.ts";
+import {
+  makeSvg,
+  makeViewport,
+  makeBrush
+} from "../../helpers/overlay.ts";
+
+// CONSTANTS
+// Mirrors the label's own estimate: 6.2px per glyph at font-size 10.
+const kCharWidth = 6.2;
+
+function makeLabel(
+  viewport = makeViewport()
+) {
+  const svg = makeSvg();
+  const label = new SelectionSizeLabel(
+    svg,
+    viewport,
+    makeBrush()
+  );
+
+  return {
+    svg,
+    label,
+    text: () => svg.querySelector("text")!
+  };
+}
+
+describe("SelectionSizeLabel", () => {
+  test("draw() anchors the size below the bottom-right corner", () => {
+    const { label, text } = makeLabel();
+
+    // zoom 4, camera (0,0): rect (1,1,16,16) -> right=68, bottom=68
+    label.draw({
+      x: 1,
+      y: 1,
+      width: 16,
+      height: 16
+    });
+
+    assert.strictEqual(text().textContent, "16×16");
+    assert.strictEqual(text().getAttribute("visibility"), "visible");
+    assert.strictEqual(text().getAttribute("text-anchor"), "end");
+    assert.strictEqual(text().getAttribute("x"), "68");
+    assert.strictEqual(text().getAttribute("y"), "82");
+  });
+
+  test("draw() reports the bounding box of any rect, unrounded", () => {
+    const { label, text } = makeLabel();
+
+    label.draw({
+      x: 0,
+      y: 0,
+      width: 3,
+      height: 17
+    });
+
+    assert.strictEqual(text().textContent, "3×17");
+  });
+
+  test("draw() hides anything smaller than 2x2 on either axis", () => {
+    const { label, text } = makeLabel();
+
+    for (const rect of [
+      { width: 1, height: 1 },
+      { width: 1, height: 8 },
+      { width: 8, height: 1 }
+    ]) {
+      label.draw({
+        x: 0,
+        y: 0,
+        ...rect
+      });
+
+      assert.strictEqual(
+        text().getAttribute("visibility"),
+        "hidden",
+        `${rect.width}x${rect.height} is too small to label`
+      );
+    }
+
+    label.draw({
+      x: 0,
+      y: 0,
+      width: 2,
+      height: 2
+    });
+
+    assert.strictEqual(
+      text().getAttribute("visibility"),
+      "visible",
+      "2x2 is the smallest labelled selection"
+    );
+  });
+
+  test("draw() hides a previously drawn label once the rect shrinks", () => {
+    const { label, text } = makeLabel();
+
+    label.draw({
+      x: 0,
+      y: 0,
+      width: 8,
+      height: 8
+    });
+    label.draw({
+      x: 0,
+      y: 0,
+      width: 8,
+      height: 1
+    });
+
+    assert.strictEqual(text().getAttribute("visibility"), "hidden");
+  });
+
+  test("the label is legible over artwork via a haloed brush-colored text", () => {
+    const { label, text } = makeLabel();
+
+    label.draw({
+      x: 0,
+      y: 0,
+      width: 4,
+      height: 4
+    });
+
+    assert.strictEqual(text().getAttribute("fill"), "#000");
+    assert.strictEqual(text().getAttribute("stroke"), "#FFF");
+    assert.strictEqual(text().getAttribute("paint-order"), "stroke");
+  });
+
+  test("draw() flips above the box when it would fall past the bottom", () => {
+    const { label, text } = makeLabel(
+      makeViewport(4, { x: 800, y: 600 })
+    );
+
+    // top=560, bottom=624: below (638) is past the 600px-tall viewport.
+    label.draw({
+      x: 0,
+      y: 140,
+      width: 16,
+      height: 16
+    });
+
+    // top - gap + fontSize = 560 - 14 + 10
+    assert.strictEqual(text().getAttribute("y"), "556");
+  });
+
+  test("draw() clamps the anchor so the label stays inside the left edge", () => {
+    const viewport = makeViewport();
+    viewport.camera.x = -10;
+    const { label, text } = makeLabel(viewport);
+
+    // right = -10 + 4*4 = 6, which would push "4×4" off the left edge.
+    label.draw({
+      x: 0,
+      y: 0,
+      width: 4,
+      height: 4
+    });
+
+    const expected = 4 + ("4×4".length * kCharWidth);
+    assert.strictEqual(
+      text().getAttribute("x"),
+      String(expected)
+    );
+  });
+
+  test("draw() hides the label when the rect left the viewport", () => {
+    const { label, text } = makeLabel(
+      makeViewport(4, { x: 800, y: 600 })
+    );
+
+    label.draw({
+      x: 0,
+      y: 0,
+      width: 4,
+      height: 4
+    });
+    assert.strictEqual(text().getAttribute("visibility"), "visible");
+
+    // left = 300 * 4 = 1200, past the 800px-wide viewport.
+    label.draw({
+      x: 300,
+      y: 0,
+      width: 4,
+      height: 4
+    });
+
+    assert.strictEqual(text().getAttribute("visibility"), "hidden");
+  });
+
+  test("clear() hides the label", () => {
+    const { label, text } = makeLabel();
+
+    label.draw({
+      x: 0,
+      y: 0,
+      width: 4,
+      height: 4
+    });
+    label.clear();
+
+    assert.strictEqual(text().getAttribute("visibility"), "hidden");
+  });
+});


### PR DESCRIPTION
close #569 